### PR TITLE
67: Set user agent to "cloudant-terraform/{version}"

### DIFF
--- a/ibm/service/cloudant/resource_ibm_cloudant.go
+++ b/ibm/service/cloudant/resource_ibm_cloudant.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"net/url"
 	"strings"
 	"time"
@@ -21,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/IBM/cloudant-go-sdk/cloudantv1"
+	"github.com/IBM/cloudant-go-sdk/common"
 	"github.com/IBM/go-sdk-core/v5/core"
 	iamidentity "github.com/IBM/platform-services-go-sdk/iamidentityv1"
 )
@@ -409,6 +411,11 @@ func getCloudantClient(d *schema.ResourceData, meta interface{}) (*cloudantv1.Cl
 	})
 	if err != nil {
 		return nil, fmt.Errorf("[ERROR] Error occured while configuring Cloudant service: %q", err)
+	}
+	if client != nil {
+		customHeaders := http.Header{}
+		customHeaders.Add("User-Agent", "cloudant-terraform/"+common.Version)
+		client.SetDefaultHeaders(customHeaders)
 	}
 
 	return client, nil


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Add "cloudant-terraform/{version}" user-agent header.

NB this is currently blocked on https://github.com/IBM-Cloud/terraform-provider-ibm/pull/3549 - after that is merged, then all other instances of the cloudant client can have these headers added here.