### PR TITLE
refactor(cloudant): handle capacity change duration more gracefully

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,8 +3,11 @@
     "files": "go.mod|go.sum|.*.map|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-03-15T13:54:53Z",
+  "generated_at": "2023-03-16T13:46:54Z",
   "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
     {
       "name": "ArtifactoryDetector"
     },
@@ -17,6 +20,12 @@
     },
     {
       "name": "BasicAuthDetector"
+    },
+    {
+      "name": "BoxDetector"
+    },
+    {
+      "name": "CloudantDetector"
     },
     {
       "ghe_instance": "github.ibm.com",
@@ -43,6 +52,9 @@
       "name": "KeywordDetector"
     },
     {
+      "name": "MailchimpDetector"
+    },
+    {
       "name": "NpmDetector"
     },
     {
@@ -56,6 +68,12 @@
     },
     {
       "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
     }
   ],
   "results": {
@@ -704,7 +722,7 @@
         "hashed_secret": "813274ccae5b6b509379ab56982d862f7b5969b6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 907,
+        "line_number": 912,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -784,7 +802,7 @@
         "hashed_secret": "c8b6f5ef11b9223ac35a5663975a466ebe7ebba9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1610,
+        "line_number": 1628,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -792,7 +810,7 @@
         "hashed_secret": "8abf4899c01104241510ba87685ad4de76b0c437",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1616,
+        "line_number": 1634,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1588,7 +1606,7 @@
         "hashed_secret": "3046d9f6cfaaeea6eed9bb7a4ab010fe49b0cfd4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 38,
+        "line_number": 37,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1596,7 +1614,7 @@
         "hashed_secret": "f855f5027fd8fdb2df3f6a6f1cf858fffcbedb0c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 98,
+        "line_number": 97,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1604,7 +1622,7 @@
         "hashed_secret": "2e81e24c4d2c84cca06ec032fc31fd9ac5409454",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 154,
+        "line_number": 153,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1612,7 +1630,7 @@
         "hashed_secret": "0498bc9e372a86de4cec00c77e2a05a79c9d0e5f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 399,
+        "line_number": 398,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1620,7 +1638,7 @@
         "hashed_secret": "f75b33f87ffeacb3a4f793a09693e672e07449ff",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 411,
+        "line_number": 410,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1628,7 +1646,7 @@
         "hashed_secret": "3db21c9f89f3c840de8358b5af922eb7f9eed330",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 582,
+        "line_number": 556,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3380,7 +3398,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 45,
+        "line_number": 47,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4152,7 +4170,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 58,
+        "line_number": 60,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/ibm/service/cloudant/resource_ibm_cloudant.go
+++ b/ibm/service/cloudant/resource_ibm_cloudant.go
@@ -17,7 +17,6 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/version"
 	rc "github.com/IBM/platform-services-go-sdk/resourcecontrollerv2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
@@ -484,17 +483,21 @@ func setCloudantInstanceCapacity(client *cloudantv1.CloudantV1, d *schema.Resour
 
 	if capacityThroughputInformation.Current != nil && capacityThroughputInformation.Current.Throughput != nil {
 		currentThroughput := capacityThroughputInformation.Current.Throughput
+		targetThroughput := currentThroughput
+		if capacityThroughputInformation.Target != nil && capacityThroughputInformation.Target.Throughput != nil {
+			targetThroughput = capacityThroughputInformation.Target.Throughput
+		}
 		// lite plan doesn't have "blocks" attr on broker's response
 		if d.Get("plan").(string) == "lite" || currentThroughput.Blocks == nil {
 			d.Set("capacity", 1)
 		} else {
-			blocks := int(*currentThroughput.Blocks)
+			blocks := int(*targetThroughput.Blocks)
 			d.Set("capacity", blocks)
 		}
 		throughput := map[string]int{
-			"query": int(*currentThroughput.Query),
-			"read":  int(*currentThroughput.Read),
-			"write": int(*currentThroughput.Write),
+			"query": int(*targetThroughput.Query),
+			"read":  int(*targetThroughput.Read),
+			"write": int(*targetThroughput.Write),
 		}
 		d.Set("throughput", throughput)
 	}
@@ -522,36 +525,7 @@ func updateCloudantInstanceCapacity(client *cloudantv1.CloudantV1, d *schema.Res
 		return err
 	}
 
-	return isWaitForCapacityUpdated(client)
-}
-
-func isWaitForCapacityUpdated(client *cloudantv1.CloudantV1) error {
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{"retry"},
-		Target:  []string{"done", "failed"},
-		Refresh: func() (interface{}, string, error) {
-			capacityThroughputInformation, err := readCloudantInstanceCapacity(client)
-			if err != nil {
-				return nil, "failed", err
-			}
-
-			state := "retry"
-			current := *capacityThroughputInformation.Current.Throughput.Blocks
-			target := *capacityThroughputInformation.Target.Throughput.Blocks
-
-			if current == target {
-				state = "done"
-			}
-
-			return current, state, nil
-		},
-		Timeout:    5 * time.Minute,
-		Delay:      5 * time.Second,
-		MinTimeout: 2 * time.Second,
-	}
-
-	_, err := stateConf.WaitForState()
-	return err
+	return nil
 }
 
 func validateCloudantInstanceCors(d *schema.ResourceData) error {

--- a/website/docs/d/cloudant.html.markdown
+++ b/website/docs/d/cloudant.html.markdown
@@ -38,7 +38,9 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `capacity` (Number) A number of blocks of throughput units. For more information, about throughput capacity, see [`blocks`](https://cloud.ibm.com/apidocs/cloudant#putcapacitythroughputconfiguration) parameter.
+* `capacity` (Number) A number of blocks of throughput units.
+
+Capacity changes are reflected immediately, but are applied asynchronously over time by the service. Large capacity jumps are not fully available for some time after modification, but typically complete within 12 hours. For more information, about throughput capacity, see [`blocks`](https://cloud.ibm.com/apidocs/cloudant#putcapacitythroughputconfiguration) parameter.
 * `cors_config` (List of Object) Configuration for CORS.
 
   Nested scheme for `cors_config`:

--- a/website/docs/r/cloudant.html.markdown
+++ b/website/docs/r/cloudant.html.markdown
@@ -50,7 +50,9 @@ configuration options:
 
 Review the argument reference that you can specify for your resource:
 
-* `capacity` - (Optional, Number) A number of blocks of throughput units. For more information, about throughput capacity, see [`blocks`](https://cloud.ibm.com/apidocs/cloudant#putcapacitythroughputconfiguration) parameter. The default value is `1`. Capacity modification is not supported for `lite` plan.
+* `capacity` - (Optional, Number) A number of blocks of throughput units. The default value is `1`. Capacity modification is not supported for `lite` plan.
+
+Capacity changes are reflected immediately, but are applied asynchronously over time by the service. Large capacity jumps are not fully available for some time after modification, but typically complete within 12 hours. For more information, about throughput capacity, see [`blocks`](https://cloud.ibm.com/apidocs/cloudant#putcapacitythroughputconfiguration) parameter.
 * `cors_config` - (Optional, Block List) Configuration for CORS.
 
   Nested scheme for `cors_config`:


### PR DESCRIPTION
Due to a throttling of capacity change operation on the back-end side it can take a number of hours to complete. This makes an instance creation operation for the instances requested with a large capacity to fail on a timeout even though the instance itself get provisioned.

This PR changes what parameters block we are using to report the capacity of the instance, allowing for the capacity change to catch up asynchronously.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccIBMCloudant'
[WARN] Set the environment variable IBM_APPID_TENANT_ID for testing AppID resources, AppID tests will fail if this is not set
...
[WARN] Set the environment variable IES_API_KEY for testing Event streams targets, the tests will fail if this is not set
=== RUN   TestAccIBMCloudantDatabaseDataSourceBasic
--- PASS: TestAccIBMCloudantDatabaseDataSourceBasic (78.23s)
=== RUN   TestAccIBMCloudantDataSource_basic
--- PASS: TestAccIBMCloudantDataSource_basic (93.71s)
=== RUN   TestAccIBMCloudantDatabaseBasic
--- PASS: TestAccIBMCloudantDatabaseBasic (106.84s)
=== RUN   TestAccIBMCloudantDatabaseAllArgs
--- PASS: TestAccIBMCloudantDatabaseAllArgs (111.71s)
=== RUN   TestAccIBMCloudant_basic
--- PASS: TestAccIBMCloudant_basic (117.63s)
=== RUN   TestAccIBMCloudant_import
--- PASS: TestAccIBMCloudant_import (156.72s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cloudant    665.785s
```
